### PR TITLE
issue-112: Fix timeout issue + WebHook notifications + bug fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,16 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-tomcat</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-undertow</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -58,6 +68,10 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-batch</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.batch</groupId>
+			<artifactId>spring-batch-integration</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.github.sps.pushover.net</groupId>
@@ -96,6 +110,10 @@
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-hateoas</artifactId>
 			<version>${springdoc.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.batch</groupId>

--- a/src/main/java/com/bompotis/netcheck/NetcheckApplication.java
+++ b/src/main/java/com/bompotis/netcheck/NetcheckApplication.java
@@ -18,6 +18,7 @@
 package com.bompotis.netcheck;
 
 import com.bompotis.netcheck.scheduler.batch.notification.config.PushoverConfig;
+import com.bompotis.netcheck.scheduler.batch.notification.config.WebhookConfig;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
@@ -41,7 +42,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication
 @EnableJpaRepositories
 @EnableScheduling
-@EnableConfigurationProperties(PushoverConfig.class)
+@EnableConfigurationProperties({PushoverConfig.class, WebhookConfig.class})
 @PropertySource(value="classpath:META-INF/build-info.properties", ignoreResourceNotFound=true)
 public class NetcheckApplication {
 

--- a/src/main/java/com/bompotis/netcheck/api/model/DomainModel.java
+++ b/src/main/java/com/bompotis/netcheck/api/model/DomainModel.java
@@ -18,6 +18,7 @@
 package com.bompotis.netcheck.api.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.hateoas.RepresentationModel;
 import org.springframework.hateoas.server.core.Relation;
@@ -52,6 +53,7 @@ public class DomainModel extends RepresentationModel<DomainModel> {
         return domain;
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public DomainCheckModel getLastChecks() {
         return lastDomainCheck;
     }

--- a/src/main/java/com/bompotis/netcheck/scheduler/batch/notification/NotificationDto.java
+++ b/src/main/java/com/bompotis/netcheck/scheduler/batch/notification/NotificationDto.java
@@ -17,11 +17,12 @@
  */
 package com.bompotis.netcheck.scheduler.batch.notification;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
-
 import java.util.Date;
+import java.util.Map;
 import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Created by Kyriakos Bompotis on 1/7/20.
@@ -65,9 +66,9 @@ public class NotificationDto {
 
     private final Boolean rootCertificatesChanged;
 
-    private final JsonObject currentState;
+    private final Map<String, Object> currentState;
 
-    private final JsonObject previousState;
+    private final Map<String, Object> previousState;
 
     public String getMessage() {
         switch (type) {
@@ -116,7 +117,7 @@ public class NotificationDto {
         return isUp ? Status.UP : Status.DOWN;
     }
 
-    public boolean isDnsResolves() {
+    public Boolean isDnsResolves() {
         return dnsResolves;
     }
 
@@ -144,11 +145,11 @@ public class NotificationDto {
         return type;
     }
 
-    public JsonObject getPreviousState() {
+    public Map<String, Object> getPreviousState() {
         return previousState;
     }
 
-    public JsonObject getCurrentState() {
+    public Map<String, Object> getCurrentState() {
         return currentState;
     }
 
@@ -165,13 +166,16 @@ public class NotificationDto {
         private Boolean issuerCertificateIsValid;
         private Date issuerCertificateExpirationDate;
         private Boolean rootCertificatesChanged;
-        private JsonObject currentState;
-        private JsonObject previousState;
+        private Map<String, Object> currentState;
+        private Map<String, Object> previousState;
         private String redirectUri;
         private String hostname;
         private Date timeCheckedOn;
         private Long responseTimeNs;
         private String ipAddress;
+        private final ObjectMapper oMapper = new ObjectMapper()
+                .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
         public Builder statusCode(Integer statusCode) {
             this.statusCode = statusCode;
@@ -184,12 +188,12 @@ public class NotificationDto {
         }
 
         public Builder currentState(Object currentState) {
-            this.currentState = new Gson().toJsonTree(currentState).getAsJsonObject();
+            this.currentState = Optional.ofNullable(currentState).isPresent() ? oMapper.convertValue(currentState, Map.class) : null;
             return this;
         }
 
         public Builder previousState(Object previousState) {
-            this.previousState = new Gson().toJsonTree(previousState).getAsJsonObject();
+            this.previousState = Optional.ofNullable(previousState).isPresent() ? oMapper.convertValue(previousState, Map.class) : null;
             return this;
         }
 

--- a/src/main/java/com/bompotis/netcheck/scheduler/batch/notification/PushoverService.java
+++ b/src/main/java/com/bompotis/netcheck/scheduler/batch/notification/PushoverService.java
@@ -35,15 +35,12 @@ import java.util.Set;
 @Service
 public class PushoverService implements NotificationService {
 
-    private final PushoverRestClient pushoverRestClient;
-
     private final PushoverConfig pushoverConfig;
 
     private static final Logger log = LoggerFactory.getLogger(PushoverService.class);
 
     @Autowired
     public PushoverService(PushoverConfig pushoverConfig) {
-        this.pushoverRestClient = new PushoverRestClient();
         this.pushoverConfig = pushoverConfig;
     }
 
@@ -55,8 +52,8 @@ public class PushoverService implements NotificationService {
     @Override
     public void notify(NotificationDto notification) throws PushoverException {
         Set<String> protocols = pushoverConfig.getNotifyOnlyFor().isEmpty() ? Set.of("HTTP","HTTPS","CERTIFICATE") : Set.copyOf(pushoverConfig.getNotifyOnlyFor());
-        if (isEnabled() && protocols.contains(notification.getType().name())) {
-            var status = pushoverRestClient.pushMessage(PushoverMessage
+        if (protocols.contains(notification.getType().name())) {
+            var status = new PushoverRestClient().pushMessage(PushoverMessage
                     .builderWithApiToken(pushoverConfig.getApiToken())
                     .setUserId(pushoverConfig.getUserIdToken())
                     .setMessage(notification.getMessage())
@@ -64,10 +61,7 @@ public class PushoverService implements NotificationService {
             );
             log.info("Pushover notification: Request id {} - Status {}.",status.getRequestId(),status.getStatus());
         } else {
-            var message = isEnabled() ?
-                    String.format("Notifications for type %s are disabled. Skipping!",notification.getType().name()) :
-                    "Pushover notifications disabled. Skipping!";
-            log.info(message);
+            log.info("Pushover notifications for type {} are disabled. Skipping!", notification.getType().name());
         }
     }
 }

--- a/src/main/java/com/bompotis/netcheck/scheduler/batch/notification/WebhookService.java
+++ b/src/main/java/com/bompotis/netcheck/scheduler/batch/notification/WebhookService.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.bompotis.netcheck.scheduler.batch.notification;
+
+import com.bompotis.netcheck.scheduler.batch.notification.config.WebhookConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Created by Kyriakos Bompotis on 10/8/20.
+ */
+@Service
+public class WebhookService implements NotificationService {
+
+    private final WebhookConfig webhookConfig;
+
+    private static final Logger log = LoggerFactory.getLogger(WebhookService.class);
+
+    @Autowired
+    public WebhookService(WebhookConfig webhookConfig) {
+        this.webhookConfig = webhookConfig;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return Optional.ofNullable(webhookConfig.getEnabled()).orElse(false);
+    }
+
+    @Override
+    public void notify(NotificationDto notification) {
+        Set<String> protocols = webhookConfig.getNotifyOnlyFor().isEmpty() ? Set.of("HTTP","HTTPS","CERTIFICATE") : Set.copyOf(webhookConfig.getNotifyOnlyFor());
+        if (protocols.contains(notification.getType().name())) {
+            log.info("Preparing client for domain {}", webhookConfig.getBaseUrl());
+            var client = WebClient
+                    .builder()
+                    .baseUrl(webhookConfig.getBaseUrl())
+                    .defaultCookie("cookieKey", "cookieValue")
+                    .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .defaultUriVariables(Collections.singletonMap("url", webhookConfig.getBaseUrl()))
+                    .build();
+            log.info("Sending notification to {}", webhookConfig.getEndpoint());
+            var response = Objects.requireNonNull(client.post()
+                    .uri(webhookConfig.getEndpoint())
+                    .body(BodyInserters.fromValue(notification))
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .exchange()
+                    .block(Duration.ofSeconds(30)))
+                    .rawStatusCode();
+            log.info("Webhook response code: {}", response);
+        } else {
+            log.info("Webhook notifications for type {} are disabled. Skipping!", notification.getType().name());
+        }
+    }
+}

--- a/src/main/java/com/bompotis/netcheck/scheduler/batch/notification/config/WebhookConfig.java
+++ b/src/main/java/com/bompotis/netcheck/scheduler/batch/notification/config/WebhookConfig.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.bompotis.netcheck.scheduler.batch.notification.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Created by Kyriakos Bompotis on 10/8/20.
+ */
+@ConfigurationProperties(prefix = "settings.notifications.webhook")
+@ConstructorBinding
+public class WebhookConfig {
+    private final Boolean enabled;
+
+    private final String baseUrl;
+
+    private final String endpoint;
+
+    private final Set<String> notifyOnlyFor;
+
+    public WebhookConfig(Boolean enabled, String baseUrl, String endpoint, Set<String> notifyOnlyFor) {
+        this.enabled = enabled;
+        this.baseUrl = baseUrl;
+        this.endpoint = endpoint;
+        var acceptableEntries = Set.of("HTTP","HTTPS","CERTIFICATE");
+        if (Optional.ofNullable(notifyOnlyFor).isEmpty() || notifyOnlyFor.isEmpty()) {
+            this.notifyOnlyFor = acceptableEntries;
+        } else {
+            var finalSet = new HashSet<String>();
+            for (var entry: notifyOnlyFor) {
+                if (acceptableEntries.contains(entry.toUpperCase())) {
+                    finalSet.add(entry.toUpperCase());
+                }
+                else {
+                    throw new IllegalArgumentException("No such type of notification:" + entry);
+                }
+            }
+            this.notifyOnlyFor = finalSet;
+        }
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public Set<String> getNotifyOnlyFor() {
+        return notifyOnlyFor;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+}

--- a/src/main/java/com/bompotis/netcheck/scheduler/batch/processor/DomainCheckProcessor.java
+++ b/src/main/java/com/bompotis/netcheck/scheduler/batch/processor/DomainCheckProcessor.java
@@ -25,11 +25,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Created by Kyriakos Bompotis on 10/6/20.
  */
 @Component
+@Transactional
 public class DomainCheckProcessor implements ItemProcessor<DomainEntity, DomainCheckEntity> {
 
     private final DomainService domainService;

--- a/src/main/java/com/bompotis/netcheck/scheduler/batch/writer/NotificationItemWriter.java
+++ b/src/main/java/com/bompotis/netcheck/scheduler/batch/writer/NotificationItemWriter.java
@@ -47,6 +47,7 @@ public class NotificationItemWriter implements ItemWriter<DomainCheckEntity> {
     public NotificationItemWriter(List<NotificationService> notificationServices) {
         var enabledNotificationServices = new ArrayList<NotificationService>();
         for (var notificationService : notificationServices) {
+            log.info("Notification provider: {} - Enabled: {}", notificationService.getClass(), notificationService.isEnabled());
             if (notificationService.isEnabled()) {
                 enabledNotificationServices.add(notificationService);
             }
@@ -105,8 +106,8 @@ public class NotificationItemWriter implements ItemWriter<DomainCheckEntity> {
                         .build());
             }
             var httpCheck = checkMap.get("HTTPS");
-            var previousHttpCheck = previousCheckMap.get("HTTP");
             if (check.isHttpsCheckChange()) {
+                var previousHttpCheck = previousCheckMap.get("HTTPS");
                 notifications.add(new NotificationDto.Builder()
                         .hostname(httpCheck.getHostname())
                         .currentState(httpCheck)
@@ -153,7 +154,7 @@ public class NotificationItemWriter implements ItemWriter<DomainCheckEntity> {
     private CertificateEntity getIssuerCertificate(Set<CertificateEntity> certificates) {
         AtomicReference<CertificateEntity> certificate = new AtomicReference<>();
         Optional.ofNullable(certificates).ifPresentOrElse(
-                (certs) -> certs.stream().filter(cert -> cert.getBasicConstraints() > 0).findFirst().ifPresent(certificate::set),
+                (certs) -> certs.stream().filter(cert -> cert.getBasicConstraints() < 0).findFirst().ifPresent(certificate::set),
                 () -> certificate.set(null)
         );
         return certificate.get();

--- a/src/main/java/com/bompotis/netcheck/service/DomainService.java
+++ b/src/main/java/com/bompotis/netcheck/service/DomainService.java
@@ -215,26 +215,45 @@ public class DomainService extends AbstractService{
         return Optional.of(convertDomainCheckEntityToDto(domainCheckEntity));
     }
 
-    public PaginatedDto<DomainDto> getPaginatedDomains(Integer page, Integer size) {
+    public PaginatedDto<DomainDto> getPaginatedDomains(Integer page, Integer size, Boolean showLastChecks) {
         var domains = new ArrayList<DomainDto>();
-        var paginatedQueryResult = domainCheckRepository.findAllLastChecksPerDomain(getDefaultPageRequest(page, size));
-        paginatedQueryResult.forEach(
-                (domain) -> domains.add(new DomainDto.Builder()
-                        .domain(domain.getDomain())
-                        .checkFrequencyMinutes(domain.getDomainEntity().getCheckFrequency())
-                        .createdAt(domain.getDomainEntity().getCreatedAt())
-                        .lastDomainCheck(convertDomainCheckEntityToDto(domain))
-                        .build()
-                )
-        );
+        if (showLastChecks) {
+            Page<DomainCheckEntity> paginatedQueryResult = domainCheckRepository.findAllLastChecksPerDomain(getDefaultPageRequest(page, size));
+            paginatedQueryResult.forEach(
+                    (domain) -> domains.add(new DomainDto.Builder()
+                            .domain(domain.getDomain())
+                            .checkFrequencyMinutes(domain.getDomainEntity().getCheckFrequency())
+                            .createdAt(domain.getDomainEntity().getCreatedAt())
+                            .lastDomainCheck(convertDomainCheckEntityToDto(domain))
+                            .build()
+                    )
+            );
+            return new PaginatedDto<>(
+                    domains,
+                    paginatedQueryResult.getTotalElements(),
+                    paginatedQueryResult.getTotalPages(),
+                    paginatedQueryResult.getNumber(),
+                    paginatedQueryResult.getNumberOfElements()
+            );
+        } else {
+            var paginatedQueryResult = domainRepository.findAll(getDefaultPageRequest(page,size));
+            paginatedQueryResult.forEach(
+                    (domain) -> domains.add(new DomainDto.Builder()
+                            .domain(domain.getDomain())
+                            .checkFrequencyMinutes(domain.getCheckFrequency())
+                            .createdAt(domain.getCreatedAt())
+                            .build()
+                    )
+            );
 
-        return new PaginatedDto<>(
-                domains,
-                paginatedQueryResult.getTotalElements(),
-                paginatedQueryResult.getTotalPages(),
-                paginatedQueryResult.getNumber(),
-                paginatedQueryResult.getNumberOfElements()
-        );
+            return new PaginatedDto<>(
+                    domains,
+                    paginatedQueryResult.getTotalElements(),
+                    paginatedQueryResult.getTotalPages(),
+                    paginatedQueryResult.getNumber(),
+                    paginatedQueryResult.getNumberOfElements()
+            );
+        }
     }
 
     public void scheduleDomainToCheck(String domain, Integer frequency) {

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -34,6 +34,21 @@
       "name": "settings.schedulers.cleanup.deleteOlderThan",
       "type": "java.lang.String",
       "description": "Minimum amount of months a check should be consider old enough to be deleted."
+    },
+    {
+      "name": "settings.notifications.webhook.enabled",
+      "type": "java.lang.String",
+      "description": "Enable or disable notifications through a Webhook."
+    },
+    {
+      "name": "settings.notifications.webhook.url",
+      "type": "java.lang.String",
+      "description": "Url of the webhook."
+    },
+    {
+      "name": "settings.notifications.webhook.notifyOnlyFor",
+      "type": "java.util.List<java.lang.String>",
+      "description": "Filter for only sending specific type of notifications."
     }
   ]
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -67,3 +67,6 @@ management:
       show-components: always
 server:
   forward-headers-strategy: native
+  compression:
+    enabled: true
+  port: 8080


### PR DESCRIPTION
- Enabled compression on responses
- Init support for Webhook notifications
- Fix timeout handling ( resolves #112 )
- Clean up exception logging for known causes
- Log enabled notification services at start up
- Fix picking wrong cert when sending notifications for cert changes
- Parameter on GET /domains to skip last Checks per domain + ignore empty last checks on response
- Accept optional payload with domain config on PUT /domain/{domain}
- Increase page size of domain reader on scheduler to 100
- Change scheduler check processing  to async.
- Replace Gson objects in Notification payload with Maps in order to fix issues when de-serializing