### PR TITLE
Added /events path to traefik configuration

### DIFF
--- a/traefik.docker-compose.yml
+++ b/traefik.docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - db
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.netcheck-api.rule=Host(`<netcheck-domain>`) && PathPrefix(`/api`,`/docs`)"
+      - "traefik.http.routers.netcheck-api.rule=Host(`<netcheck-domain>`) && PathPrefix(`/api`,`/docs`,`/events`)"
       - "traefik.http.routers.netcheck-api.entrypoints=websecure"
       - "traefik.http.routers.netcheck-api.service=netcheck-api"
       - "traefik.http.routers.netcheck-api.tls.certresolver=mainresolver"


### PR DESCRIPTION
As far as I understand the "/events" backend path should be added to the traefik configuration, I get an error on the frontend otherwise.

Great project by the way, looks awesome and works like a charm.

Greetings,

Andy